### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,5 +49,7 @@ jobs:
     name: "Publish"
     needs: [full]
     uses: ./.github/workflows/task-code-metrics.yaml
+    permissions:
+      contents: read
     secrets:
       private-ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}

--- a/.github/workflows/deploy-nuget.yaml
+++ b/.github/workflows/deploy-nuget.yaml
@@ -127,6 +127,8 @@ jobs:
   bump:
     name: Bump Version
     needs: [deploy]
+    permissions:
+      contents: write
     uses: ./.github/workflows/bump-version.yaml
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/pr2.yaml
+++ b/.github/workflows/pr2.yaml
@@ -16,6 +16,8 @@ jobs:
   autoformat:
     name: "Autoformat"
     uses: ./.github/workflows/task-autoformat-check.yaml
+    permissions:
+      contents: read
   full:
     name: "Full Build"
     uses: ./.github/workflows/task-full.yaml

--- a/.github/workflows/task-autoformat-check.yaml
+++ b/.github/workflows/task-autoformat-check.yaml
@@ -1,5 +1,8 @@
 name: Autoformat Check
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/task-autoformat-fix.yaml
+++ b/.github/workflows/task-autoformat-fix.yaml
@@ -11,6 +11,8 @@ jobs:
   sp4-autoformat:
     name: Fix
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout as Contributor
         uses: actions/checkout@v4

--- a/.github/workflows/task-code-metrics.yaml
+++ b/.github/workflows/task-code-metrics.yaml
@@ -2,6 +2,9 @@
 
 name: Analyze Code Metrics
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/task-publish-changelog.yaml
+++ b/.github/workflows/task-publish-changelog.yaml
@@ -13,6 +13,9 @@ jobs:
   publish-changelog:
     name: Changelog
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: 🚀 Trigger Remote Workflow
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/SerTetora/ScottPlot/security/code-scanning/12](https://github.com/SerTetora/ScottPlot/security/code-scanning/12)

To fix the issue, we need to explicitly define the permissions required for the workflow. Since the workflow triggers a remote workflow using the GitHub API, it likely requires `contents: read` and possibly `actions: write`. However, we should start with the minimal permissions required and adjust if necessary.

The fix involves adding a `permissions` block at the root level of the workflow or within the specific job (`publish-changelog`). In this case, adding it to the job ensures the permissions are scoped to the job that uses the `GH_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
